### PR TITLE
switch from every half-an-hour to every 2 hour builds

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -10,7 +10,7 @@ on:
       # Do not trigger on workflow changes, can do manual trigger if needed
       - '.github/**'
   schedule:
-    - cron:  '*/30 * * * *'
+    - cron:  '15 */2 * * *'
   workflow_dispatch:
     inputs:
       invoke_args:


### PR DESCRIPTION
The full build takes quite a while, and it's liely not good to
overlap the triggers with each other by accident, for example.