### PR TITLE
Add arm/v6 to the default build platforms

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ while getopts r:i:t:p:a:f:b: option; do
   esac
 done
 
-PLATFORM=${PLATFORM:-linux/arm64,linux/arm/v7}
+PLATFORM=${PLATFORM:-linux/arm64,linux/arm/v7,linux/arm/v6}
 PATCH=${PATCH:-}
 FROM_REPLACE=${FROM_REPLACE:-imrehg/archiveteam-arm-}
 


### PR DESCRIPTION
The README.md mentions ARMv6 but it isn't being built. This would enable builds for BCM2835-based Raspberry Pi computers.