### PR TITLE
Fix Docker Hub URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ The following lists of projects are supported so far and have images:
 
 | Project | Official Image | ARM Image (this repo) |
 | ------- | -------------- | --------------------- |
-| [Reddit](https://wiki.archiveteam.org/index.php/Reddit) | `atdr.meo.ws/archiveteam/reddit-grab` | [`imrehg/archiveteam-arm-reddit-grab`](https://hub.docker.com/repository/docker/imrehg/archiveteam-arm-reddit-grab) |
-| [Telegram](https://wiki.archiveteam.org/index.php/Telegram) | `atdr.meo.ws/archiveteam/telegram-grab` | [`imrehg/archiveteam-arm-telegram-grab`](https://hub.docker.com/repository/docker/imrehg/archiveteam-arm-telegram-grab) |
-| Ukraine | `atdr.meo.ws/archiveteam/ua-grab` | [`imrehg/archiveteam-arm-ua-grab`](https://hub.docker.com/repository/docker/imrehg/archiveteam-arm-ua-grab) |
+| [Reddit](https://wiki.archiveteam.org/index.php/Reddit) | `atdr.meo.ws/archiveteam/reddit-grab` | [`imrehg/archiveteam-arm-reddit-grab`](https://hub.docker.com/r/imrehg/archiveteam-arm-reddit-grab) |
+| [Telegram](https://wiki.archiveteam.org/index.php/Telegram) | `atdr.meo.ws/archiveteam/telegram-grab` | [`imrehg/archiveteam-arm-telegram-grab`](https://hub.docker.com/r/imrehg/archiveteam-arm-telegram-grab) |
+| Ukraine | `atdr.meo.ws/archiveteam/ua-grab` | [`imrehg/archiveteam-arm-ua-grab`](https://hub.docker.com/r/imrehg/archiveteam-arm-ua-grab) |
 
 
 In addition to the project images, the following base images are provided:
 
 | Official Image | ARM Image (this repo) |
 | -------------- | --------------------- |
-| `atdr.meo.ws/archiveteam/wget-lua` | [`imrehg/archiveteam-arm-wget-lua`](https://hub.docker.com/repository/docker/imrehg/archiveteam-arm-wget-lua) (gnutls version only) |
-| `atdr.meo.ws/archiveteam/grab-base` | [`imrehg/archiveteam-arm-grab-base`](https://hub.docker.com/repository/docker/imrehg/archiveteam-arm-grab-base) (gnutls version only) |
+| `atdr.meo.ws/archiveteam/wget-lua` | [`imrehg/archiveteam-arm-wget-lua`](https://hub.docker.com/r/imrehg/archiveteam-arm-wget-lua) (gnutls version only) |
+| `atdr.meo.ws/archiveteam/grab-base` | [`imrehg/archiveteam-arm-grab-base`](https://hub.docker.com/r/imrehg/archiveteam-arm-grab-base) (gnutls version only) |
 
 ## Multiarch builds
 


### PR DESCRIPTION
You have to be logged in to access the old URLs
Old: 
![msedge_hbFVqkBTtG](https://github.com/imrehg/archiveteam-arm/assets/4153203/88107b59-00bd-42c9-a1d0-089670a88323)

New: 
![msedge_19I3sfERHu](https://github.com/imrehg/archiveteam-arm/assets/4153203/8beaeb92-9f7e-4c6d-b290-bac98f5b579c)
